### PR TITLE
Ignore case on fetching expires header

### DIFF
--- a/lib/public_key_store.ex
+++ b/lib/public_key_store.ex
@@ -13,9 +13,10 @@ defmodule FirebaseJwt.PublicKeyStore do
 
   def fetch_firebase_keys() do
     response = HTTPoison.get!(@googleCertificateUrl)
-    expire = Timex.parse!(response.headers |> Map.new() |> Map.get("expires"), "{RFC1123}")
+    {_, expire} = Enum.find(response.headers, fn {k, _} -> String.downcase(k) == "expires" end)
+
     store(:public_keys, Jason.decode!(response.body))
-    store(:expire, expire)
+    store(:expire, Timex.parse!(expire, "{RFC1123}"))
   end
 
   def store(key, value) do


### PR DESCRIPTION
I got following error when started iex.

```
Interactive Elixir (1.9.1) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> [error] Task #PID<0.314.0> started from #PID<0.312.0> terminating
** (FunctionClauseError) no function clause matching in Timex.Parse.DateTime.Parser.parse!/3
    (timex) lib/parse/datetime/parser.ex:77: Timex.Parse.DateTime.Parser.parse!(nil, "{RFC1123}", Timex.Parse.DateTime.Tokenizers.Default)
    (firebase_jwt) lib/public_key_store.ex:16: FirebaseJwt.PublicKeyStore.fetch_firebase_keys/0
    (firebase_jwt) lib/public_key_updater.ex:19: FirebaseJwt.PublicKeyUpdater.run/0
    (elixir) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Function: &FirebaseJwt.PublicKeyUpdater.run/0
    Args: []


... snip


[info] Application firebase_jwt exited: shutdown
```

I found that fetching "Expires" header fails because it expects "expires" header.

```
iex(3)> {:ok, res} = HTTPoison.get "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
iex(4)> res.headers
[
  {"Date", "Fri, 27 Sep 2019 05:12:00 GMT"},
  {"Expires", "Fri, 27 Sep 2019 11:46:52 GMT"},
  {"Content-Type", "application/json; charset=UTF-8"},
  {"Vary", "X-Origin"},
  {"Vary", "Referer"},
  {"Server", "ESF"},
  {"X-XSS-Protection", "0"},
  {"X-Frame-Options", "SAMEORIGIN"},
  {"X-Content-Type-Options", "nosniff"},
  {"Cache-Control", "public, max-age=23692, must-revalidate, no-transform"},
  {"Age", "36"},
  {"Alt-Svc",
   "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"},
  {"Accept-Ranges", "none"},
  {"Vary", "Origin,Accept-Encoding"},
  {"Transfer-Encoding", "chunked"}
]
```

So this pull request changes to ignore cases when get the value from headers.

thanks.