### PR TITLE
Support simulator mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+version: 2.1
+
+executors:
+  elixir:
+    docker:
+      - image: cimg/elixir:1.14.3
+        environment:
+          MIX_ENV: test
+jobs:
+  test:
+    executor: elixir
+    working_directory: ~/project
+    steps:
+      - checkout:
+          path: ~/project
+      - attach_workspace:
+          at: ~/project
+
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+
+      - restore_cache: # restores saved mix cache
+          keys:
+            - v1-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v1-cache-{{ .Branch }}
+            - v1-cache
+
+      - run: mix do deps.get, compile # get updated dependencies & compile them
+
+      - save_cache:
+          key: v1-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          paths:
+            - "deps"
+            - "_build"
+
+      - run: mix test
+
+workflows:
+  version: 2
+  multiple-test:
+    jobs:
+      - test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FirebaseJwt
 
-**TODO: Add description**
+This verifies Firebase `id_token` and fetch claims from it.
 
 ## Installation
 
@@ -15,7 +15,36 @@ def deps do
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/firebase_jwt](https://hexdocs.pm/firebase_jwt).
+## Usage
 
+```elixir
+{:ok, claims} = FirebaseJwt.verify(token)
+
+# claims
+{
+  "aud": "ex-firebase-jwt",
+  "auth_time": 1681029095,
+  "exp": 1681032695,
+  "firebase": {
+    "identities": {
+    },
+    "sign_in_provider": "anonymous"
+  },
+  "iat": 1681029095,
+  "iss": "https://example.com/ecpplus/ex-firebase-jwt",
+  "provider_id": "anonymous",
+  "sub": "pq8Lh98ElfZkLJzO2jDuOgHbk26G",
+  "user_id": "pq8Lh98ElfZkLJzO2jDuOgHbk26G"
+}
+```
+
+## For Firebase simulator
+
+Firebase simulator makes none algorithm JWTs.
+
+```elixir
+config :firebase_jwt,
+  simulator_mode: true
+```
+
+This gets you the claims without verifying JWT. (Don't use this for production).

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,5 @@
 import Config
+
+config :firebase_jwt,
+  debug_log: false,
+  simulator_mode: false

--- a/lib/public_key_store.ex
+++ b/lib/public_key_store.ex
@@ -18,7 +18,7 @@ defmodule FirebaseJwt.PublicKeyStore do
 
     store(:public_keys, Jason.decode!(response.body))
     store(:expire, Timex.parse!(expire, "{RFC1123}"))
-    Logger.debug("#{__MODULE__} public keys updated.")
+    Application.get_env(:firebase_jwt, :debug_log) && Logger.debug("#{__MODULE__} public keys updated.")
   end
 
   def store(key, value) do

--- a/lib/public_key_updater.ex
+++ b/lib/public_key_updater.ex
@@ -15,7 +15,7 @@ defmodule FirebaseJwt.PublicKeyUpdater do
   def run() do
     # Allow endless restart
     :timer.sleep(1000)
-    Logger.debug("[#{__MODULE__}] runs.")
+    Application.get_env(:firebase_jwt, :debug_log) && Logger.debug("[#{__MODULE__}] runs.")
 
     PublicKeyStore.fetch_firebase_keys()
     expire = PublicKeyStore.get(:expire) |> DateTime.to_unix(:millisecond)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule FirebaseJwt.MixProject do
   def project do
     [
       app: :firebase_jwt,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/firebase_jwt_test.exs
+++ b/test/firebase_jwt_test.exs
@@ -1,8 +1,32 @@
 defmodule FirebaseJwtTest do
   use ExUnit.Case
-  doctest FirebaseJwt
 
-  test "greets the world" do
-    assert FirebaseJwt.hello() == :world
+  def json_web_token_string() do
+    "{\"aud\":\"ex-firebase-jwt\",\"auth_time\":1681029095,\"exp\":1681032695,\"firebase\":{\"identities\":{},\"sign_in_provider\":\"anonymous\"},\"iat\":1681029095,\"iss\":\"https://example.com/ecpplus/ex-firebase-jwt\",\"provider_id\":\"anonymous\",\"sub\":\"pq8Lh98ElfZkLJzO2jDuOgHbk26G\",\"user_id\":\"pq8Lh98ElfZkLJzO2jDuOgHbk26G\"}"
+  end
+
+  describe "FirebaseJwt.verity/1" do
+    test "when simulator_mode=true returns claims" do
+      :ok = Application.put_env(:firebase_jwt, :simulator_mode, true)
+
+      claim = "{\"aud\":\"ex-firebase-jwt\",\"auth_time\":1681029095,\"exp\":1681032695,\"firebase\":{\"identities\":{},\"sign_in_provider\":\"anonymous\"},\"iat\":1681029095,\"iss\":\"https://example.com/ecpplus/ex-firebase-jwt\",\"provider_id\":\"anonymous\",\"sub\":\"pq8Lh98ElfZkLJzO2jDuOgHbk26G\",\"user_id\":\"pq8Lh98ElfZkLJzO2jDuOgHbk26G\"}" |> Base.encode64()
+      token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.#{claim}."
+
+      {:ok, claims} = FirebaseJwt.verify(token)
+
+      assert claims["sub"] == "pq8Lh98ElfZkLJzO2jDuOgHbk26G"
+      assert claims["user_id"] == "pq8Lh98ElfZkLJzO2jDuOgHbk26G"
+    end
+
+    test "when simulator_mode=nil verity token and raise error" do
+      :ok = Application.put_env(:firebase_jwt, :simulator_mode, nil)
+
+      claim = "{\"aud\":\"ex-firebase-jwt\",\"auth_time\":1681029095,\"exp\":1681032695,\"firebase\":{\"identities\":{},\"sign_in_provider\":\"anonymous\"},\"iat\":1681029095,\"iss\":\"https://example.com/ecpplus/ex-firebase-jwt\",\"provider_id\":\"anonymous\",\"sub\":\"pq8Lh98ElfZkLJzO2jDuOgHbk26G\",\"user_id\":\"pq8Lh98ElfZkLJzO2jDuOgHbk26G\"}" |> Base.encode64()
+      token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.#{claim}."
+
+      assert_raise MatchError, fn ->
+        FirebaseJwt.verify(token)
+      end
+    end
   end
 end


### PR DESCRIPTION
Firebase simulator makes none algorithm JWTs. 

```elixir
config :firebase_jwt,
  simulator_mode: true
```

This skips verifying JWT (Don't use this for production).